### PR TITLE
Example test of CI rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,9 +30,15 @@ github:
   features:
     issues: true
   protected_branches:
-    main:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
+    test_main:
+      required_status_checks:
+        strict: true
+        contexts:
+          - "test-matrix"
+          - "merge-build-artifacts"
+          - "rat"
+          - "build-docs"
+          - "test-matrix"
 
 staging:
   whoami: asf-staging


### PR DESCRIPTION
DO NOT MERGE

This PR is to demonstrate asf rules to verify we are correctly requiring CI green in order to merge.